### PR TITLE
Call `toString` on message strings

### DIFF
--- a/addon/initializers/toastr.js
+++ b/addon/initializers/toastr.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 var proxyGenerator = function(name){
   return function(msg = '', title = '') {
-    window.toastr[name](msg.toString(), title.toString())
+    window.toastr[name](msg.toString(), title.toString());
   };
 };
 

--- a/addon/initializers/toastr.js
+++ b/addon/initializers/toastr.js
@@ -1,8 +1,23 @@
+import Ember from 'ember';
+
 export function initialize(container, application, options) {
   var injectAs = options.injectAs;
-  toastr.options = options.toastrOptions;
+  window.toastr.options = options.toastrOptions;
 
-  application.register('notify:main', toastr, { instantiate: false, singleton: true });
+  application.register('notify:main', Object.assign({}, toastr, Ember.Object.create({
+    success(msg) {
+      window.toastr.success(msg.toString());
+    },
+    info(msg) {
+      window.toastr.info(msg.toString());
+    },
+    warning(msg) {
+      window.toastr.warning(msg.toString());
+    },
+    error(msg) {
+      window.toastr.error(msg.toString());
+    }
+  })), { instantiate: false, singleton: true });
   application.inject('route', injectAs, 'notify:main');
   application.inject('controller', injectAs, 'notify:main');
   application.inject('component', injectAs, 'notify:main');

--- a/addon/initializers/toastr.js
+++ b/addon/initializers/toastr.js
@@ -1,22 +1,20 @@
 import Ember from 'ember';
 
+var proxyGenerator = function(name){
+  return function(msg = '', title = '') {
+    window.toastr[name](msg.toString(), title.toString())
+  };
+};
+
 export function initialize(container, application, options) {
   var injectAs = options.injectAs;
   window.toastr.options = options.toastrOptions;
 
   application.register('notify:main', Object.assign({}, toastr, Ember.Object.create({
-    success(msg) {
-      window.toastr.success(msg.toString());
-    },
-    info(msg) {
-      window.toastr.info(msg.toString());
-    },
-    warning(msg) {
-      window.toastr.warning(msg.toString());
-    },
-    error(msg) {
-      window.toastr.error(msg.toString());
-    }
+    success: proxyGenerator('success'),
+    info: proxyGenerator('info'),
+    warning: proxyGenerator('warning'),
+    error: proxyGenerator('error')
   })), { instantiate: false, singleton: true });
   application.inject('route', injectAs, 'notify:main');
   application.inject('controller', injectAs, 'notify:main');

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,5 +13,9 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
+  if (process.env.EMBER_ENV === 'test') {
+    app.import('vendor/phantom-js-polyfills.js');
+  }
+
   return app.toTree();
 };

--- a/vendor/phantom-js-polyfills.js
+++ b/vendor/phantom-js-polyfills.js
@@ -1,0 +1,33 @@
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+if (!Object.assign) {
+  Object.defineProperty(Object, 'assign', {
+    enumerable: false,
+    configurable: true,
+    writable: true,
+    value: function(target) {
+      'use strict';
+      if (target === undefined || target === null) {
+        throw new TypeError('Cannot convert first argument to object');
+      }
+
+      var to = Object(target);
+      for (var i = 1; i < arguments.length; i++) {
+        var nextSource = arguments[i];
+        if (nextSource === undefined || nextSource === null) {
+          continue;
+        }
+        nextSource = Object(nextSource);
+
+        var keysArray = Object.keys(nextSource);
+        for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
+          var nextKey = keysArray[nextIndex];
+          var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
+          if (desc !== undefined && desc.enumerable) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+      return to;
+    }
+  });
+}


### PR DESCRIPTION
I ran into a problem w/ passing translated strings (https://github.com/jamesarosen/ember-i18n) to `toastr.success`). 

The issues is that `this.i18n.t('my.translation.path')` returns a `SafeString` object (not a raw string). Passing this directly to `toastr` results in empty text, for this reason as it doesn't know what to do w/ a `SafeString`.

The simplest solution I could think of is to, instead of registering toastr directly, register a proxy of sorts and call `toString` on messages before passing them on.
## NOTE

The failing tests are also failing in master..
