### PR TITLE
Add support for use in nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ module.exports = {
 
   included: function(app, parentAddon) {
     var target = (parentAddon || app);
+    if (target.app) {
+      target = target.app;
+    }
     var bowerDir = target.bowerDirectory;
 
     target.import(bowerDir + '/toastr/toastr.js');


### PR DESCRIPTION
# Purpose

I was getting an error when trying to use ember-toastr as a nested addon:

``` bash
⏚ ⌂69% [Sam:~/Documents/workspace/ember-osf] feature/node-mixin+(+37/-173)+* 131 ± ember s
target.import is not a function
TypeError: target.import is not a function
    at Class.module.exports.included (/Users/Sam/Documents/workspace/ember-osf/node_modules/ember-toastr/index.js:11:18)
    at /Users/Sam/Documents/workspace/ember-osf/node_modules/ember-cli/lib/models/addon.js:244:32
    at Array.map (native)
    at Class.eachAddonInvoke (/Users/Sam/Documents/workspace/ember-osf/node_modules/ember-cli/lib/models/addon.js:242:22)
    at Class.Addon.included (/Users/Sam/Documents/workspace/ember-osf/node_modules/ember-cli/lib/models/addon.js:349:8)
    at EmberAddon.<anonymous> (/Users/Sam/Documents/workspace/ember-osf/node_modules/ember-cli/lib/broccoli/ember-app.js:433:15)
    at Array.filter (native)
    at EmberAddon.EmberApp._notifyAddonIncluded (/Users/Sam/Documents/workspace/ember-osf/node_modules/ember-cli/lib/broccoli/ember-app.js:428:45)
    at EmberAddon.EmberApp [as appConstructor] (/Users/Sam/Documents/workspace/ember-osf/node_modules/ember-cli/lib/broccoli/ember-app.js:109:8)
    at new EmberAddon (/Users/Sam/Documents/workspace/ember-osf/node_modules/ember-cli/lib/broccoli/ember-addon.js:38:8)
```

And made my change based on some reading around and debugger sessions. I've tested this behavior in an addon and in a regular app. All seems OK.

h/t https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-182526160
