### PR TITLE
allow for clearing and removing individual toasts

### DIFF
--- a/addon/services/toast.js
+++ b/addon/services/toast.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 var proxyGenerator = function (name) {
   return function (msg = '', title = '', options = {}) {
-    window.toastr[name](msg.toString(), title.toString(), options);
+    return window.toastr[name](msg.toString(), title.toString(), options);
   };
 };
 
@@ -12,11 +12,11 @@ export default Ember.Service.extend({
   warning: proxyGenerator('warning'),
   error: proxyGenerator('error'),
 
-  clear() {
-    window.toastr.clear();
+  clear(toastElement) {
+    window.toastr.clear(toastElement);
   },
 
-  remove() {
-    window.toastr.remove();
+  remove(toastElement) {
+    window.toastr.remove(toastElement);
   }
 });


### PR DESCRIPTION
toastr allows you to individually clear and remove toasts, this change lets you do that. This shouldn't break anything since you can safely ignore the arguments for clear and remove. Manually tested on one of my ember apps.