### PR TITLE
Pull toastr from npm instead of bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: node_js
 node_js:
   - "0.12"
+  - "4"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
-  - "4"
+  - "6"
+  - "latest"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: node_js
 node_js:
+  - "4"
   - "6"
-  - "latest"
 
 sudo: false
 

--- a/blueprints/ember-toastr/index.js
+++ b/blueprints/ember-toastr/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  description: 'Install toastr.js from bower',
+  description: 'Install toastr.js from npm',
 
   // prevent complaining
   normalizeEntityName: function() {
@@ -13,6 +13,6 @@ module.exports = {
   // }
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('toastr');
+    return this.addPackageToProject({name: 'toastr'});
   }
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
     );
   },
 
-  treeForVendor(vendorTree){
+  treeForVendor: function(vendorTree){
     var trees = [];
     if(vendorTree){
       trees.push(vendorTree);

--- a/index.js
+++ b/index.js
@@ -18,18 +18,8 @@ module.exports = {
       target = target.app;
     }
 
-    target.import(
-        {
-          development: vendor + '/toastr/toastr.js',
-          production: vendor + '/toastr/build/toastr.min.js'
-        }
-    );
-    target.import(
-        {
-          development: vendor + '/toastr/build/toastr.css',
-          production: vendor + '/toastr/build/toastr.min.css'
-        }
-    );
+    target.import(vendor + '/toastr/toastr.js');
+    target.import(vendor + '/toastr/build/toastr.css');
   },
 
   treeForVendor: function(vendorTree){

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = {
       trees.push(vendorTree);
     }
     trees.push(new Funnel(toastrPath, {
-      srcDir: '/build',
+      srcDir: 'build',
       include: ['toastr.js', 'toastr.css'],
       destDir: 'toastr',
     }));

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = {
   name: 'ember-toastr',
 
   included: function(app, parentAddon) {
-    let vendor = this.treePaths.vendor;
-    let target = (parentAddon || app);
+    var vendor = this.treePaths.vendor;
+    var target = (parentAddon || app);
 
     if (target.app) {
       target = target.app;
@@ -33,7 +33,7 @@ module.exports = {
   },
 
   treeForVendor(vendorTree){
-    let trees = [];
+    var trees = [];
     if(vendorTree){
       trees.push(vendorTree);
     }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,48 @@
 /* jshint node: true */
 'use strict';
 
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+var path = require('path');
+var toastrPath = path.dirname(require.resolve('toastr'));
+
 module.exports = {
   name: 'ember-toastr',
 
   included: function(app, parentAddon) {
-    var target = (parentAddon || app);
+    let vendor = this.treePaths.vendor;
+    let target = (parentAddon || app);
+
     if (target.app) {
       target = target.app;
     }
-    var bowerDir = target.bowerDirectory;
 
-    target.import(bowerDir + '/toastr/toastr.js');
-    target.import(bowerDir + '/toastr/toastr.css');
+    target.import(
+        {
+          development: vendor + '/toastr/toastr.js',
+          production: vendor + '/toastr/toastr.min.js'
+        }
+    );
+
+    target.import(
+        {
+          development: vendor + '/toastr/toastr.css',
+          production: vendor + '/toastr/toastr.min.css'
+        }
+    );
+  },
+
+  treeForVendor(vendorTree){
+    let trees = [];
+    if(vendorTree){
+      trees.push(vendorTree);
+    }
+    trees.push(new Funnel(toastrPath, {
+      srcDir: '/build',
+      include: ['toastr.js', 'toastr.css'],
+      destDir: 'toastr',
+    }));
+
+    return new MergeTrees(trees);
   }
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var Funnel = require('broccoli-funnel');
 var MergeTrees = require('broccoli-merge-trees');
 var path = require('path');
+
 var toastrPath = path.dirname(require.resolve('toastr'));
 
 module.exports = {
@@ -20,14 +21,13 @@ module.exports = {
     target.import(
         {
           development: vendor + '/toastr/toastr.js',
-          production: vendor + '/toastr/toastr.min.js'
+          production: vendor + '/toastr/build/toastr.min.js'
         }
     );
-
     target.import(
         {
-          development: vendor + '/toastr/toastr.css',
-          production: vendor + '/toastr/toastr.min.css'
+          development: vendor + '/toastr/build/toastr.css',
+          production: vendor + '/toastr/build/toastr.min.css'
         }
     );
   },
@@ -37,12 +37,14 @@ module.exports = {
     if(vendorTree){
       trees.push(vendorTree);
     }
-    trees.push(new Funnel(toastrPath, {
-      srcDir: 'build',
-      include: ['toastr.js', 'toastr.css'],
-      destDir: 'toastr',
-    }));
 
-    return new MergeTrees(trees);
+    var toastrTree = new Funnel(toastrPath, {
+      include: ['toastr.js', 'build/toastr.*'],
+      destDir: 'toastr',
+    });
+
+    trees.push(toastrTree);
+
+    return new MergeTrees(trees, { overwrite: true });
   }
 };

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
-    "ember-cli-babel": "^5.0.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-try": "0.0.6"
+    "ember-try": "0.0.6",
+    "toastr": "^2.1.2"
   },
   "keywords": [
     "ember-addon",
@@ -46,7 +46,7 @@
     "toastr"
   ],
   "dependencies": {
-    "toastr": "^2.1.2"
+    "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "toastr"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "toastr": "^2.1.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
+    "ember-cli-babel": "^5.0.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
@@ -45,7 +46,6 @@
     "toastr"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0",
     "toastr": "^2.1.2"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli": "1.13.1",
     "ember-cli-app-version": "0.4.0",
     "ember-cli-content-security-policy": "0.4.0",


### PR DESCRIPTION
Resolve #14 
Other changes:
Travis build file changed to test for node 4 and 6.
Remove testing for older nodes beacuse of ES6 language support.

Tests passing locally, travis is green also.