### PR TITLE
Remove toastr messages on teardown

### DIFF
--- a/addon/services/toast.js
+++ b/addon/services/toast.js
@@ -50,5 +50,10 @@ export default Ember.Service.extend({
       this.set('toasts', Ember.A([]));
     }
     window.toastr.remove(toastElement);
+  },
+
+  willDestroy() {
+    this._super(...arguments);
+    this.remove();
   }
 });


### PR DESCRIPTION
Removing the open toastr messages is primarily helpful in test which avoids manual work to cleanup before or after each test.